### PR TITLE
:bug: Fix: Update footer to '2016'/GS of WO

### DIFF
--- a/agenda.html
+++ b/agenda.html
@@ -68,13 +68,11 @@
           </li>
           <li><strong>Testing &amp; Share</strong> (3:00 - 3:30)</li>
         </ul>
-        
+
       </div><!-- .site-content .about-content -->
 
       <div class="site-footer">
-
-
-        <p>&copy; 2014 <a href="http://seesparkbox.com" target="_blank">Sparkbox</a><br /><em>This site is for educational purposes in connection with the <a href="http://www.gswo.org/" target="_blank">Girl Scouts of the USA</a>. All image rights are retained solely by the original sources.</em></p>
+        <p>&copy; 2016 <a href="http://seesparkbox.com" target="_blank">Sparkbox</a><br /><em>This site is for educational purposes in connection with the <a href="http://www.gswo.org/" target="_blank">Girl Scouts of Western Ohio</a>. All image rights are retained solely by the original sources.</em></p>
       </div><!-- .site-footer -->
 
     </div><!-- .site -->

--- a/example-site.html
+++ b/example-site.html
@@ -36,7 +36,7 @@
         </ul>
 
         <h3>HTML &amp; Layout</h3>
-        
+
         <ul>
           <li><strong>Beyonce Content:</strong> <a href="http://codepen.io/kaseybon/pen/0f605d6e11a887f26664a6f02b1013c8?editors=100" target="_blank">CodePen</a>
           <li><strong>Beyonce Content w/Markup:</strong> <a href="http://codepen.io/kaseybon/pen/cbb47e9fb4b9b526df71a0045c4cf84d?editors=100" target="_blank">CodePen</a></li>
@@ -44,18 +44,16 @@
         </ul>
 
         <h3>CSS</h3>
-        
+
         <ul>
           <li><strong>Style Your Website:</strong> <a href="beyonce/" target="_blank">Example Site</a></li>
-        </ul> 
+        </ul>
       </div><!-- .site-content .about-content -->
 
       <div class="site-footer">
-
-
-        <p>&copy; 2014 <a href="http://seesparkbox.com" target="_blank">Sparkbox</a><br /><em>This site is for educational purposes in connection with the <a href="http://www.gswo.org/" target="_blank">Girl Scouts of the USA</a>. All image rights are retained solely by the original sources.</em></p>
+        <p>&copy; 2016 <a href="http://seesparkbox.com" target="_blank">Sparkbox</a><br /><em>This site is for educational purposes in connection with the <a href="http://www.gswo.org/" target="_blank">Girl Scouts of Western Ohio</a>. All image rights are retained solely by the original sources.</em></p>
       </div><!-- .site-footer -->
-
+      
     </div><!-- .site -->
 
   </body>

--- a/index.html
+++ b/index.html
@@ -102,9 +102,7 @@
       </div><!-- .site-content .resources-content -->
 
       <div class="site-footer">
-
-
-        <p>&copy; 2014 <a href="http://seesparkbox.com" target="_blank">Sparkbox</a><br /><em>This site is for educational purposes in connection with the <a href="http://www.gswo.org/" target="_blank">Girl Scouts of Western Ohio</a>. All image rights are retained solely by the original sources.</em></p>
+        <p>&copy; 2016 <a href="http://seesparkbox.com" target="_blank">Sparkbox</a><br /><em>This site is for educational purposes in connection with the <a href="http://www.gswo.org/" target="_blank">Girl Scouts of Western Ohio</a>. All image rights are retained solely by the original sources.</em></p>
       </div><!-- .site-footer -->
 
     </div><!-- .site -->

--- a/prerequisites.html
+++ b/prerequisites.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width" />
-    
+
     <link href="normalize.css" rel="stylesheet" type="text/css" />
     <link href="styles.css" rel="stylesheet" type="text/css" />
     <link href='http://fonts.googleapis.com/css?family=Montserrat:400,700' rel='stylesheet' type='text/css'>
@@ -34,12 +34,11 @@
         <ul class="link-list">
           <li><a href="https://divshot.com" target="_blank">Setup a Divshot Account</a></li>
           <li><a href="http://c758482.r82.cf2.rackcdn.com/Sublime%20Text%202.0.2.dmg" target="_blank">Install the Sublime Text Editor</a></li>
-        </ul>  
+        </ul>
       </div><!-- .site-content .about-content -->
 
       <div class="site-footer">
-        
-        <p>&copy; 2014 <a href="http://seesparkbox.com" target="_blank">Sparkbox</a><br /><em>This site is for educational purposes in connection with the <a href="http://www.gswo.org/" target="_blank">Girl Scouts of the USA</a>. All image rights are retained solely by the original sources.</em></p>
+        <p>&copy; 2016 <a href="http://seesparkbox.com" target="_blank">Sparkbox</a><br /><em>This site is for educational purposes in connection with the <a href="http://www.gswo.org/" target="_blank">Girl Scouts of Western Ohio</a>. All image rights are retained solely by the original sources.</em></p>
       </div><!-- .site-footer -->
 
     </div><!-- .site -->

--- a/slides.html
+++ b/slides.html
@@ -29,13 +29,11 @@
       <div class="site-content about-content">
         <h2 class="section-header">Workshop Slides</h2>
 
-        
+
       </div><!-- .site-content .about-content -->
 
       <div class="site-footer">
-
-
-        <p>&copy; 2014 <a href="http://seesparkbox.com" target="_blank">Sparkbox</a><br /><em>This site is for educational purposes in connection with the <a href="http://www.gswo.org/" target="_blank">Girl Scouts of the USA</a>. All image rights are retained solely by the original sources.</em></p>
+        <p>&copy; 2016 <a href="http://seesparkbox.com" target="_blank">Sparkbox</a><br /><em>This site is for educational purposes in connection with the <a href="http://www.gswo.org/" target="_blank">Girl Scouts of Western Ohio</a>. All image rights are retained solely by the original sources.</em></p>
       </div><!-- .site-footer -->
 
     </div><!-- .site -->

--- a/templates.html
+++ b/templates.html
@@ -64,9 +64,7 @@
       </div><!-- .site-content .about-content -->
 
       <div class="site-footer">
-
-
-        <p>&copy; 2014 <a href="http://seesparkbox.com" target="_blank">Sparkbox</a><br /><em>This site is for educational purposes in connection with the <a href="http://www.gswo.org/" target="_blank">Girl Scouts of the USA</a>. All image rights are retained solely by the original sources.</em></p>
+        <p>&copy; 2016 <a href="http://seesparkbox.com" target="_blank">Sparkbox</a><br /><em>This site is for educational purposes in connection with the <a href="http://www.gswo.org/" target="_blank">Girl Scouts of Western Ohio</a>. All image rights are retained solely by the original sources.</em></p>
       </div><!-- .site-footer -->
 
     </div><!-- .site -->


### PR DESCRIPTION
Replaces previous pull request to resolve these issues. 

  - Change footer link text from "Girl Scouts of the USA" to "Girl Scouts of Western Ohio"
  - Change footer copyright date from '2014' to '2016'
  - Update all .html files for above.

  Closes #13 , #14 , #21 